### PR TITLE
Ensure JWT_SECRET for backend e2e tests

### DIFF
--- a/backend/.env.test
+++ b/backend/.env.test
@@ -1,0 +1,1 @@
+JWT_SECRET=test_secret

--- a/backend/test/jest-e2e.json
+++ b/backend/test/jest-e2e.json
@@ -1,5 +1,9 @@
 {
-  "moduleFileExtensions": ["js", "json", "ts"],
+  "moduleFileExtensions": [
+    "js",
+    "json",
+    "ts"
+  ],
   "rootDir": "..",
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
@@ -8,5 +12,8 @@
   },
   "moduleNameMapper": {
     "^@/(.*)$": "<rootDir>/src/$1"
-  }
+  },
+  "setupFiles": [
+    "<rootDir>/test/setup-env.ts"
+  ]
 }

--- a/backend/test/setup-env.ts
+++ b/backend/test/setup-env.ts
@@ -1,0 +1,10 @@
+import { config } from 'dotenv';
+import { resolve } from 'path';
+
+// Load environment variables from .env.test if present
+config({ path: resolve(__dirname, '../.env.test') });
+
+// Fallback secret if not defined
+if (!process.env.JWT_SECRET) {
+  process.env.JWT_SECRET = 'test_secret';
+}


### PR DESCRIPTION
## Summary
- load `.env.test` before running backend e2e tests
- provide fallback JWT secret for tests

## Testing
- `bash install_dependencies.sh`
- `npm --prefix backend run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_684a951f47548329b62cc0a1d7236ec9