### PR TITLE
Add lint fix script

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,12 @@ Run the helper script to install packages for both the backend and frontend:
 ./install_dependencies.sh
 ```
 
+### Lint fix
+Run ESLint for both the backend and frontend projects and automatically fix issues:
+```bash
+./scripts/lint-fix.sh
+```
+
 ### Database migration and seeding
 ```bash
 cd backend

--- a/scripts/lint-fix.sh
+++ b/scripts/lint-fix.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+(cd backend && npm run lint -- --fix)
+(cd frontend && npm exec next lint -- --fix)


### PR DESCRIPTION
## Summary
- add `scripts/lint-fix.sh` helper
- document lint fix script in README

## Testing
- `npm run test` *(fails: jest not found)*
- `npm run test:e2e` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aae6cd12c8329bf90f9ee22b8916e