### PR TITLE
Add JwtPayload type and improve jwtDecode usage

### DIFF
--- a/frontend/src/app/context/AuthContext.tsx
+++ b/frontend/src/app/context/AuthContext.tsx
@@ -3,7 +3,7 @@
 import { createContext, useContext, useEffect, useState, ReactNode } from "react";
 import { jwtDecode } from "jwt-decode";
 import { useRouter } from "next/navigation";
-import { Role, SubRole } from "@/types/auth";
+import { Role, SubRole, JwtPayload } from "@/types/auth";
 
 interface AuthContextType {
   isAuthenticated: boolean;
@@ -30,7 +30,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     const token = localStorage.getItem("token");
     if (token) {
       try {
-        const decoded = jwtDecode<{ role: Role; subRole?: SubRole }>(token);
+        const decoded = jwtDecode<JwtPayload & { subRole?: SubRole }>(token);
         setRole(decoded.role);
         setSubRole(decoded.subRole || null);
         setIsAuthenticated(true);

--- a/frontend/src/lib/api/login.ts
+++ b/frontend/src/lib/api/login.ts
@@ -1,5 +1,6 @@
 import axios from '@/lib/axiosConfig';
 import { jwtDecode } from 'jwt-decode';
+import type { JwtPayload } from '@/types/auth';
 import Cookies from "js-cookie";
 
 export async function login(email: string, password: string): Promise<{ token: string; role: string }> {
@@ -11,7 +12,7 @@ export async function login(email: string, password: string): Promise<{ token: s
   const token = res.data.accessToken;
   const rememberToken = res.data.rememberToken;
 
-  const decoded: any = jwtDecode(token);
+  const decoded = jwtDecode<JwtPayload>(token);
   localStorage.setItem('token', token);
   localStorage.setItem('role', decoded.role);
   localStorage.setItem('tenantId', decoded.tenantId);

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,2 +1,7 @@
 export type Role = "admin" | "user" | "staff";
 export type SubRole = "manager" | "staff" | "cashier" | "basic";
+
+export interface JwtPayload {
+  role: Role;
+  tenantId: string;
+}


### PR DESCRIPTION
## Summary
- define `JwtPayload` interface with `role` and `tenantId`
- type JWT decode calls using `JwtPayload`

## Testing
- `./scripts/lint-fix.sh` *(fails: Cannot find package '@eslint/js')*
- `cd backend && npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab79f8f5c83298c311b6ef111e3e9