### PR TITLE
Remove unused import

### DIFF
--- a/frontend/src/components/ReservationModal.jsx
+++ b/frontend/src/components/ReservationModal.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import apiClient from '@/lib/apiClient';
 import PaymentForm from './PaymentForm';
 
 export default function ReservationModal(props) {


### PR DESCRIPTION
## Summary
- remove leftover `apiClient` import from `ReservationModal.jsx`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b287cbe9883298a9f8f8f237410b8