### PR TITLE
Implement setupCompleted flag

### DIFF
--- a/backend/prisma/migrations/20250615072416_add_setup_completed/migration.sql
+++ b/backend/prisma/migrations/20250615072416_add_setup_completed/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Tenant" ADD COLUMN     "setupCompleted" BOOLEAN NOT NULL DEFAULT false;
+

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -17,6 +17,7 @@ model Tenant {
   type      String // 業種（salon, clinic など）
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+  setupCompleted Boolean @default(false)
 
   users          User[]
   services       Service[]

--- a/backend/src/controllers/setup.controller.ts
+++ b/backend/src/controllers/setup.controller.ts
@@ -1,5 +1,5 @@
 import * as bcrypt from 'bcrypt';
-import { Controller, Post, Body, Get, Put, Query, UseGuards } from '@nestjs/common';
+import { Controller, Post, Body, Get, Put, Query, UseGuards, Req } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { PrismaService } from '../../prisma/prisma.service';
 import { TenantService } from '../services/tenant.service';
@@ -24,7 +24,7 @@ export class SetupController {
 
   @UseGuards(AuthGuard('jwt'))
   @Post()
-  async createSetup(@Body() body: any) {
+  async createSetup(@Body() body: any, @Req() req: any) {
     // 1. パスワードをハッシュ化
     const hashedPassword = await bcrypt.hash(body.admin.password, 10);
 
@@ -198,6 +198,15 @@ export class SetupController {
       }
 
       return tenantId;
+    });
+
+    await this.prisma.tenant.update({
+      where: { id: result },
+      data: { setupCompleted: true },
+    });
+
+    await this.prisma.user.delete({
+      where: { id: req.user.userId },
     });
 
     return {


### PR DESCRIPTION
## Summary
- add `setupCompleted` field to `Tenant`
- generate migration for this new field
- update `createSetup` to accept `@Req()`
- set `setupCompleted` after setup and delete requesting user

## Testing
- `npm run test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_684e748745688329bc3b098673df395c