### PR TITLE
Fix login redirection when settings missing

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -24,26 +24,30 @@ export default function LoginPage() {
   useEffect(() => {
     if (!isAuthenticated) return;
 
+    const tenantId =
+      typeof window !== "undefined" && localStorage.getItem("tenantId");
+
     if (role === "admin") {
-      const tenantId =
-        typeof window !== "undefined" && localStorage.getItem("tenantId");
       if (!tenantId) {
         router.replace("/admin/calendar");
         return;
       }
-      apiClient
-        .get("/settings", { params: { tenantId } })
-        .then(() => {
+
+      const checkSettings = async () => {
+        try {
+          await apiClient.get("/settings", { params: { tenantId } });
           router.replace("/admin/calendar");
-        })
-        .catch((err) => {
+        } catch (err: any) {
           if (err.response?.status === 404) {
             router.replace("/settings/common");
           } else {
             console.error(err);
             alert("設定取得に失敗しました");
           }
-        });
+        }
+      };
+
+      checkSettings();
     } else {
       router.replace("/user/calendar");
     }


### PR DESCRIPTION
## Summary
- handle missing settings on login page by checking `/settings`

## Testing
- `bash install_dependencies.sh`
- `cd backend && npm test`
- `cd ../frontend && npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e7bb84f808329a44c084b4a6439bf